### PR TITLE
Don't lock brakeman in to old version

### DIFF
--- a/pronto-brakeman.gemspec
+++ b/pronto-brakeman.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'pronto', '~> 0.2.0'
-  s.add_dependency 'brakeman', '~> 2.3.1'
+  s.add_dependency 'brakeman'
   s.add_development_dependency 'rake', '~> 10.1.0'
   s.add_development_dependency 'rspec', '~> 2.14.0'
 end


### PR DESCRIPTION
It's constantly updated with latest security fixes, so it should rather be the latest version when possible, right?
