### PR TITLE
Relax brakeman dependency

### DIFF
--- a/pronto-brakeman.gemspec
+++ b/pronto-brakeman.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency('pronto', '~> 0.9.0')
-  s.add_runtime_dependency('brakeman', '~> 3.2', '>= 3.2.0')
+  s.add_runtime_dependency('brakeman', '>= 3.2.0')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
This change modifies the gemspec to remove the pessimistic operator to
limit brakeman to be a version < 4.0. With the release of brakeman 4.0,
this should allow users of this gem to update their brakeman
dependencies to the latest version, while also continuing to support the
use of > 3.2 versions of brakeman.

Please let me know if you'd like me to update this to support an upper bound.
I wasn't sure how you would like to manage supporting (or not) multiple major versions
of brakeman.