### PR TITLE
Use .to_s on warning.file in patch_for_warning()

### DIFF
--- a/lib/pronto/brakeman.rb
+++ b/lib/pronto/brakeman.rb
@@ -51,7 +51,7 @@ module Pronto
 
     def patch_for_warning(ruby_patches, warning)
       ruby_patches.find do |patch|
-        patch.new_file_full_path.to_s == warning.file
+        patch.new_file_full_path.to_s == warning.file.to_s
       end
     end
   end


### PR DESCRIPTION
At least with Ruby v2.6.3 and Rails 6 the comparison `patch.new_file_full_path.to_s == warning.file` does not work because `warning.file` returns an object and not a path.

This small patch uses `warning.file.to_s` to remedy the issue.